### PR TITLE
APP-149847 secure pendo api key via ZAF secure settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,92 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Is
+
+Zendo is a React app that runs inside a Zendesk ticket sidebar iframe. It uses the Zendesk Apps Framework (ZAF) to read ticket/requester data and the Pendo Integration API to display visitor/account analytics to support agents.
+
+## Commands
+
+```bash
+npm start              # Dev server (rarely useful — requires ZAF context)
+npm run build          # Development build → copies output to zendesk-app/assets/
+npm run build:prod     # Production build (sets REACT_APP_HOST_ENV=production)
+npm run package        # Full release: clean → build:prod → strip source maps → zat package
+npm test               # Run tests with react-scripts (jest)
+```
+
+To run a single test file:
+```bash
+npm test -- --testPathPattern=App.test
+```
+
+ZAT (Zendesk Apps Tools) is a Ruby gem required for packaging and local serving. Install with `gem install zendesk_apps_tools`. On Apple Silicon, run `bundle config set force_ruby_platform true` before installing nokogiri.
+
+Local ZAT server settings go in `zendesk-app/settings.yml` (gitignored):
+```yml
+apiKey: "<PENDO_INTEGRATION_KEY>"       # integration key UUID only, no suffix
+pendo-host: "app.pendo.io"             # API host for your target env
+pendo-lookup-field: "agent/email"
+enable-user-lookup-field: true
+```
+
+**Note:** `apiKey` is a secure setting. `zat server` + `?zat=true` will NOT work for
+testing — Zendesk's secure proxy returns `InstallationNotFound` because ZAT has no real
+installation record. See [Testing locally](#testing-locally) below.
+
+## Architecture
+
+### Data Flow
+
+All data flows through RxJS 5 observables. `src/Streams.js` is the central hub — it wires together ZAF and Pendo data sources into memoized observable streams consumed by React containers.
+
+**Sources:**
+- `src/sources/ZAFClient.js` — wraps the global `ZAFClient` (injected by Zendesk) as RxJS observables. On load it also resizes the iframe and initializes per-ticket storage.
+- `src/sources/PendoClient.js` — wraps Pendo REST API calls as RxJS observables. All requests go through ZAF's `client.request()` with `secure: true`, so the API key is substituted server-side and never exposed in the browser. The target host comes from the `pendo-host` app setting (e.g. `app.pendo.io`, `app.eu.pendo.io`, `app.pendo-dev.pendo-dev.com`).
+- `src/sources/Storage.js` — localStorage wrapper providing per-ticket storage and a common storage namespace, with change events as observables.
+
+**Aggregations** (`src/aggregations/`): Functions that construct Pendo aggregation pipeline request bodies (passed to `PendoClient.runAggregation`).
+
+**Containers** use `recycle` (a reactive React component library over RxJS) rather than Redux. `SectionFactory.js` is a factory that produces `recycle` components for displaying visitor or account metadata sections.
+
+### Visitor Lookup Strategy
+
+The app supports two modes for finding the Pendo visitor matching the Zendesk ticket requester:
+1. **By ID** (default): Uses the requester's email as the Pendo visitor ID.
+2. **By metadata field**: Looks up via a Pendo metadata field like `agent/email`. Controlled by the `enable-user-lookup-field` and `pendo-lookup-field` app settings in `zendesk-app/manifest.json`.
+
+### Zendesk App Config
+
+`zendesk-app/manifest.json` defines the app parameters. Key settings:
+
+| Setting | Secure | Required | Description |
+|---|---|---|---|
+| `apiKey` | ✓ | ✓ | Pendo integration key (UUID only, no suffix) |
+| `pendo-host` | — | ✓ | Pendo API host (e.g. `app.pendo.io`, `app.eu.pendo.io`) |
+| `pendo-lookup-field` | — | — | Metadata field for visitor lookup (e.g. `visitor/email`) |
+| `enable-user-lookup-field` | — | — | Toggle metadata-field lookup vs. lookup by ID |
+
+The built React app is served from `zendesk-app/assets/index.html` inside the Zendesk ticket sidebar.
+
+### Testing Locally
+
+Because `apiKey` uses ZAF secure settings, Zendesk's proxy must resolve the `{{setting.apiKey}}` placeholder server-side. `zat server` alone cannot do this — requests return `422 InstallationNotFound`.
+
+**The only way to fully test is to install the app as a private app:**
+
+1. Build and package:
+   ```bash
+   npm run package
+   ```
+   This produces `zendesk-app/tmp/pendo-*.zip`.
+
+2. In your Zendesk dev instance, go to **Admin → Apps and integrations → Zendesk Support apps → Upload private app** and upload the zip.
+
+3. During installation, configure:
+   - **apiKey** — your Pendo integration key (UUID only)
+   - **pendo-host** — the Pendo API host for your env (e.g. `app.pendo-dev.pendo-dev.com` for dev/link envs)
+
+4. Open a ticket **without** `?zat=true` in the URL. The installed app loads and API calls go through the secure proxy successfully.
+
+> If you previously had the Pendo app installed, disable it first — otherwise the two installations conflict.

--- a/src/Streams.js
+++ b/src/Streams.js
@@ -36,13 +36,14 @@ const Streams = {
 
     const obs = Rx.Observable.zip(
       ZAF.getEmail(),
-      ZAF.getApiToken(),
+      ZAF.getClient(),
+      ZAF.getPendoHost(),
       ZAF.getIDLookupField()
-    ).flatMap( ([email, token, field]) => {
+    ).flatMap( ([email, client, host, field]) => {
       lookup = field;
       return field === 'ID' || !field ?
-        Pendo.fetchUserById(token, email) :
-        Pendo.findUsersByField(token, field, email);
+        Pendo.fetchUserById(client, host, email) :
+        Pendo.findUsersByField(client, host, field, email);
     })
     .take(1) // or could reduce?
     .map((visitor) => {
@@ -73,16 +74,17 @@ const Streams = {
     const $ = new Rx.AsyncSubject();
 
     const obs = Rx.Observable.zip(
-      ZAF.getApiToken(),
+      ZAF.getClient(),
+      ZAF.getPendoHost(),
       Streams.getVisitorStream()
         .map((v) => {
           if (!v.accountIds)
             return null;
           return v.accountIds[0]
         })
-    ).flatMap( ([token, acctId]) => {
+    ).flatMap( ([client, host, acctId]) => {
       if (!acctId) throw Error('No account')
-      return Pendo.findAccountStream(token, acctId)
+      return Pendo.findAccountStream(client, host, acctId)
     })
     .subscribe(
       (n) => {
@@ -98,8 +100,8 @@ const Streams = {
 
   getMetadataSchema: R.memoize((type) => {
     const $ = new Rx.AsyncSubject();
-    const obs = ZAF.getApiToken()
-      .flatMap( (token) => Pendo.getMetadataSchema(token, type) )
+    const obs = Rx.Observable.zip(ZAF.getClient(), ZAF.getPendoHost())
+      .flatMap( ([client, host]) => Pendo.getMetadataSchema(client, host, type) )
       .subscribe(
         (n) => {
           $.next(n);
@@ -177,12 +179,13 @@ const Streams = {
   getNumUsers: R.memoize(() => {
     const $ = new Rx.AsyncSubject();
     const obs = Rx.Observable.zip(
-      ZAF.getApiToken(),
+      ZAF.getClient(),
+      ZAF.getPendoHost(),
       Streams.getAccountStream().map((a) => a.id)
     )
-      .flatMap(([token, acctId]) => {
+      .flatMap(([client, host, acctId]) => {
         const agg = NumUsers(acctId);
-        return Pendo.runAggregation(token, agg);
+        return Pendo.runAggregation(client, host, agg);
       }).reduce((acc, val) => {
         if (!acc.title) {
           acc.title = "Unique Users Last 30 Days";
@@ -214,12 +217,13 @@ const Streams = {
     const $ = new Rx.AsyncSubject();
 
     const obs = Rx.Observable.zip(
-      ZAF.getApiToken(),
+      ZAF.getClient(),
+      ZAF.getPendoHost(),
       Streams.getVisitorStream().map((v) => v.id)
     )
-      .flatMap( ([token, visitorId]) => {
+      .flatMap( ([client, host, visitorId]) => {
         const agg = NumFeaturesUsed(visitorId);
-        return Pendo.runAggregation(token, agg);
+        return Pendo.runAggregation(client, host, agg);
       }).reduce((acc, val) => {
         const fName = val["Feature Name"];
         if (!acc.title) {
@@ -254,12 +258,13 @@ const Streams = {
     const $ = new Rx.AsyncSubject();
 
     const obs = Rx.Observable.zip(
-      ZAF.getApiToken(),
+      ZAF.getClient(),
+      ZAF.getPendoHost(),
       Streams.getVisitorStream().map((v) => v.id)
     )
-      .flatMap( ([token, visitorId]) => {
+      .flatMap( ([client, host, visitorId]) => {
         const agg = NumDaysRequest(visitorId);
-        return Pendo.runAggregation(token, agg);
+        return Pendo.runAggregation(client, host, agg);
       }).reduce((acc, val) => {
         if (!acc.title) {
           acc.title = "Days Active Last 30 Days";
@@ -286,11 +291,12 @@ const Streams = {
   getVisitorHistory: R.memoize((date) => {
     const $ = new Rx.AsyncSubject();
     const obs = Rx.Observable.zip(
-      ZAF.getApiToken(),
+      ZAF.getClient(),
+      ZAF.getPendoHost(),
       Streams.getVisitorStream().map( (v) => v.id )
     )
-      .flatMap( ([token, visitorId]) => {
-        return Pendo.getVisitorHistory(token, visitorId, date);
+      .flatMap( ([client, host, visitorId]) => {
+        return Pendo.getVisitorHistory(client, host, visitorId, date);
       })
       .map(R.reverse)
       .catch( err => Rx.Observable.of(err) )
@@ -306,16 +312,16 @@ const Streams = {
   }),
 
   getPendoModels: R.memoize((date) => {
-    return ZAF.getApiToken()
-      .flatMap((token) => {
+    return Rx.Observable.zip(ZAF.getClient(), ZAF.getPendoHost())
+      .flatMap(([client, host]) => {
         return Rx.Observable.zip(
           Streams.getVisitorHistory(date)
             .map( (history) => R.filter(R.propEq('type', 'guide'), history) )
             .map( (guides) => R.map(R.prop('guideId'), guides) )
-            .flatMap( (guideIds) => Pendo.getGuides(token, guideIds) ),
-          Pendo.getPages(token),
-          Pendo.getFeatures(token),
-          Pendo.getTrackTypes(token)
+            .flatMap( (guideIds) => Pendo.getGuides(client, host, guideIds) ),
+          Pendo.getPages(client, host),
+          Pendo.getFeatures(client, host),
+          Pendo.getTrackTypes(client, host)
         )
       })
   })

--- a/src/containers/Header.js
+++ b/src/containers/Header.js
@@ -7,8 +7,6 @@ import IconButton from 'material-ui/IconButton';
 import Streams from '../Streams';
 import ZAF from '../sources/ZAFClient';
 
-import Pendo from '../sources/PendoClient';
-
 import '../styles/Header.css';
 
 const Header = recycle({
@@ -33,13 +31,13 @@ const Header = recycle({
       sources.select(IconButton)
         .addListener('onClick')
         .reducer((state) => {
-          window.open(`${Pendo.getUrl(state.token).url}/visitor/${state.id}`, '_newtab');
+          window.open(`https://${state.host}/visitor/${state.id}`, '_newtab');
           return state;
         }),
 
-        ZAF.getApiToken()
-        .reducer((state, token) => {
-            state.token = token;
+        ZAF.getPendoHost()
+        .reducer((state, host) => {
+            state.host = host;
             return state;
         }),
 

--- a/src/sources/PendoClient.js
+++ b/src/sources/PendoClient.js
@@ -1,17 +1,5 @@
-import PropTypes from 'prop-types';
 import Rx from 'rxjs';
 import R from 'ramda';
-import 'whatwg-fetch';
-
-function checkStatus(response) {
-  if (response.status >= 200 && response.status < 300) {
-    return response
-  } else {
-    var error = new Error(response.statusText)
-    error.response = response
-    throw error
-  }
-}
 
 /*
 * Takes a Pendo metadata fieldname like `agent/email` and modifies to force
@@ -33,234 +21,161 @@ const toLowerify = (mdFieldName) => {
   }
 }
 
+const secureHeaders = { 'X-Pendo-Integration-Key': '{{setting.apiKey}}' };
+
 const Pendo = {
 
-  prod: process.env.REACT_APP_HOST_ENV === 'production',
-
-  initialize(token) {
-    Pendo.getToken = () => token;
+  getBaseUrl(host) {
+    return `https://${host}`;
   },
 
-  getUrl(token) {
-    token = token || Pendo.getToken();
-
-    if (Pendo.prod === false) {
-      const integrationKey = token.split('.')[0];
-      return {
-        url: `https://pendo-dev.appspot.com`,
-        integrationKey
-      };
-    }
-    const [integrationKey, suffix] = token.split('.');
-    if (typeof suffix === 'undefined' || suffix === 'us') {
-      return {
-        url: 'https://app.pendo.io',
-        integrationKey
-      };
-    }
-    return {
-      url: `https://app.${suffix}.pendo.io`,
-      integrationKey
-    };
-  },
-
-  fetchUserById(token, email) {
-    const { url, integrationKey } = this.getUrl(token);
-    return Rx.Observable.create((observer) => {
-      fetch(`${url}/api/v1/visitor/${email}`, {
-        method: 'GET',
-        headers: { 'X-Pendo-Integration-Key': integrationKey }
+  fetchUserById(client, host, email) {
+    const baseUrl = Pendo.getBaseUrl(host);
+    return Rx.Observable.fromPromise(
+      client.request({
+        url: `${baseUrl}/api/v1/visitor/${email}`,
+        type: 'GET',
+        headers: secureHeaders,
+        secure: true
       })
-        .then(checkStatus)
-        .then(res => res.json())
-        .then(j => {
-          observer.next(j);
-          observer.complete();
-        })
-        .catch(err => observer.error(err))
-    });
+    );
   },
 
-  findUsersByField(token, field, email) {
-    const { url, integrationKey } = this.getUrl(token);
+  findUsersByField(client, host, field, email) {
     field = toLowerify(field);
+    const baseUrl = Pendo.getBaseUrl(host);
     return Rx.Observable.create((observer) => {
-      fetch(`${url}/api/v1/visitor/metadata/${field}/${email}`, {
-        method: 'GET',
-        headers: { 'X-Pendo-Integration-Key': integrationKey }
-      })
-        .then(checkStatus)
-        .then(res => res.json())
-        .then(users => {
-          if (!users || users.length === 0)
-            throw new Error('No Users Found');
-          users.map((user) => observer.next(user))
-          observer.complete();
-        })
-        .catch(err => observer.error(err))
+      client.request({
+        url: `${baseUrl}/api/v1/visitor/metadata/${field}/${email}`,
+        type: 'GET',
+        headers: secureHeaders,
+        secure: true
+      }).then(users => {
+        if (!users || users.length === 0)
+          throw new Error('No Users Found');
+        users.map((user) => observer.next(user));
+        observer.complete();
+      }).catch(err => observer.error(err));
     });
   },
 
-  findAccountStream(token, accountId) {
-    const { url, integrationKey } = this.getUrl(token);
-    return Rx.Observable.create((observer) => {
-      fetch(`${url}/api/v1/account/${accountId}`, {
-        method: 'GET',
-        headers: { 'X-Pendo-Integration-Key': integrationKey }
+  findAccountStream(client, host, accountId) {
+    const baseUrl = Pendo.getBaseUrl(host);
+    return Rx.Observable.fromPromise(
+      client.request({
+        url: `${baseUrl}/api/v1/account/${accountId}`,
+        type: 'GET',
+        headers: secureHeaders,
+        secure: true
       })
-        .then(checkStatus)
-        .then(res => res.json())
-        .then(j => {
-          observer.next(j);
-          observer.complete();
-        })
-        .catch(err => observer.error(err))
-    });
+    );
   },
 
-  runAggregation(token, agg) {
-    const { url, integrationKey } = this.getUrl(token);
+  runAggregation(client, host, agg) {
+    const baseUrl = Pendo.getBaseUrl(host);
     return Rx.Observable.create((observer) => {
-      fetch(`${url}/api/v1/aggregation`, {
-        method: 'POST',
+      client.request({
+        url: `${baseUrl}/api/v1/aggregation`,
+        type: 'POST',
         headers: {
-          'X-Pendo-Integration-Key': integrationKey,
+          ...secureHeaders,
           'content-type': 'application/json;charset=utf-8'
         },
-        body: JSON.stringify(agg)
-      })
-        .then(checkStatus)
-        .then(res => res.json())
-        .then(obj => {
-          obj.results.map((r) => observer.next(r));
-          observer.complete();
-        })
-        .catch(err => observer.error(err))
+        contentType: 'application/json;charset=utf-8',
+        data: JSON.stringify(agg),
+        secure: true
+      }).then(obj => {
+        obj.results.map((r) => observer.next(r));
+        observer.complete();
+      }).catch(err => observer.error(err));
     });
   },
 
-  getMetadataSchema(token, type) {
-    const { url, integrationKey } = this.getUrl(token);
-    return Rx.Observable.create((observer) => {
-      fetch(`${url}/api/v1/metadata/schema/${type}`, {
-        method: 'GET',
-        headers: { 'X-Pendo-Integration-Key': integrationKey }
+  getMetadataSchema(client, host, type) {
+    const baseUrl = Pendo.getBaseUrl(host);
+    return Rx.Observable.fromPromise(
+      client.request({
+        url: `${baseUrl}/api/v1/metadata/schema/${type}`,
+        type: 'GET',
+        headers: secureHeaders,
+        secure: true
       })
-        .then(checkStatus)
-        .then(res => res.json())
-        .then(obj => {
-          observer.next(obj);
-          observer.complete();
-        })
-        .catch(err => observer.error(err))
-    });
+    );
   },
 
-  getVisitorHistory(token, visitorId, endDate) {
-    const { url, integrationKey } = this.getUrl(token);
+  getVisitorHistory(client, host, visitorId, endDate) {
+    const baseUrl = Pendo.getBaseUrl(host);
     endDate.setHours(0); endDate.setMinutes(0); endDate.setSeconds(0); endDate.setMilliseconds(0);
     const starttime = endDate.getTime();
-    return Rx.Observable.create((observer) => {
-      fetch(`${url}/api/v1/visitor/${visitorId}/history?starttime=${starttime}`, {
-        method: 'GET',
-        headers: { 'X-Pendo-Integration-Key': integrationKey }
+    return Rx.Observable.fromPromise(
+      client.request({
+        url: `${baseUrl}/api/v1/visitor/${visitorId}/history?starttime=${starttime}`,
+        type: 'GET',
+        headers: secureHeaders,
+        secure: true
       })
-        .then(checkStatus)
-        .then(res => res.json())
-        .then(obj => {
-          observer.next(obj);
-          observer.complete();
-        })
-        .catch(err => observer.error(err))
-    });
+    );
   },
 
-  getPages(token) {
-    const { url, integrationKey } = this.getUrl(token);
-    return Rx.Observable.create((observer) => {
-      fetch(`${url}/api/v1/page?expand=*`, {
-        method: 'GET',
-        headers: { 'X-Pendo-Integration-Key': integrationKey }
+  getPages(client, host) {
+    const baseUrl = Pendo.getBaseUrl(host);
+    return Rx.Observable.fromPromise(
+      client.request({
+        url: `${baseUrl}/api/v1/page?expand=*`,
+        type: 'GET',
+        headers: secureHeaders,
+        secure: true
       })
-        .then(checkStatus)
-        .then(res => res.json())
-        .then(obj => {
-          observer.next(obj);
-          observer.complete();
-        })
-        .catch(err => observer.error(err))
-    })
+    );
   },
 
-  getFeatures(token) {
-    const { url, integrationKey } = this.getUrl(token);
-    return Rx.Observable.create((observer) => {
-      fetch(`${url}/api/v1/feature?expand=*`, {
-        method: 'GET',
-        headers: { 'X-Pendo-Integration-Key': integrationKey }
+  getFeatures(client, host) {
+    const baseUrl = Pendo.getBaseUrl(host);
+    return Rx.Observable.fromPromise(
+      client.request({
+        url: `${baseUrl}/api/v1/feature?expand=*`,
+        type: 'GET',
+        headers: secureHeaders,
+        secure: true
       })
-        .then(checkStatus)
-        .then(res => res.json())
-        .then(obj => {
-          observer.next(obj);
-          observer.complete();
-        })
-        .catch(err => observer.error(err))
-    })
+    );
   },
 
-  getGuides(token, ids) {
-    const { url, integrationKey } = this.getUrl(token);
+  getGuides(client, host, ids) {
+    const baseUrl = Pendo.getBaseUrl(host);
     if (!ids.length) return Rx.Observable.of([]);
 
     return Rx.Observable.create((observer) => {
-      fetch(`${url}/api/v1/guide?id=${ids.join(',')}`, {
-        method: 'GET',
-        headers: { 'X-Pendo-Integration-Key': integrationKey }
-      })
-        .then(checkStatus) // if one isn't found then whole request errors
-        .then(res => res.json())
-        .then(obj => {
-          observer.next(obj);
-          observer.complete();
-        })
-        .catch(err => {
-          // observer.error(err)
-          observer.next([]);
-          observer.complete();
-        })
-    })
+      client.request({
+        url: `${baseUrl}/api/v1/guide?id=${ids.join(',')}`,
+        type: 'GET',
+        headers: secureHeaders,
+        secure: true
+      }).then(obj => {
+        observer.next(obj);
+        observer.complete();
+      }).catch(err => {
+        observer.next([]);
+        observer.complete();
+      });
+    });
   },
 
-  getTrackTypes(token) {
-    const { url, integrationKey } = this.getUrl(token);
-    return Rx.Observable.create((observer) => {
-      fetch(`${url}/api/v1/tracktype?expand=*`, {
-        method: 'GET',
-        headers: { 'X-Pendo-Integration-Key': integrationKey }
+  getTrackTypes(client, host) {
+    const baseUrl = Pendo.getBaseUrl(host);
+    return Rx.Observable.fromPromise(
+      client.request({
+        url: `${baseUrl}/api/v1/tracktype?expand=*`,
+        type: 'GET',
+        headers: secureHeaders,
+        secure: true
       })
-        .then(checkStatus)
-        .then(res => res.json())
-        .then(obj => {
-          observer.next(obj);
-          observer.complete();
-        })
-        .catch(err => observer.error(err))
-    });
+    );
   },
 
   getItemId(item) {
     return item.pageId || item.featureId || item.guideId || item.trackTypeId;
   }
-};
-
-Pendo.fetchUserById.propTypes = {
-  email: PropTypes.string.isRequired,
-  token: PropTypes.string.isRequired
-};
-Pendo.findAccountStream.propTypes = {
-  accountId: PropTypes.string.isRequired,
-  token: PropTypes.string.isRequired
 };
 
 export default Pendo;

--- a/src/sources/PendoClient.test.js
+++ b/src/sources/PendoClient.test.js
@@ -1,0 +1,241 @@
+import Pendo from './PendoClient';
+
+const mockRequest = jest.fn();
+const mockClient = { request: mockRequest };
+const HOST = 'app.pendo.io';
+const SECURE_HEADER = { 'X-Pendo-Integration-Key': '{{setting.apiKey}}' };
+
+beforeEach(() => {
+  mockRequest.mockReset();
+});
+
+// ─── getBaseUrl ───────────────────────────────────────────────────────────────
+
+describe('getBaseUrl', () => {
+  [
+    ['app.pendo.io',                 'https://app.pendo.io'],
+    ['app.eu.pendo.io',              'https://app.eu.pendo.io'],
+    ['app.pendo-dev.pendo-dev.com',  'https://app.pendo-dev.pendo-dev.com'],
+    ['app.pendo-link.pendo-dev.com', 'https://app.pendo-link.pendo-dev.com'],
+  ].forEach(([host, expected]) => {
+    it(`builds URL for ${host}`, () => {
+      expect(Pendo.getBaseUrl(host)).toBe(expected);
+    });
+  });
+});
+
+// ─── Secure request contract ──────────────────────────────────────────────────
+// Every API method must proxy through ZAF with {{setting.apiKey}} so the key is
+// never exposed in the browser. Verify the invariant for every method.
+
+describe('secure request contract', () => {
+  [
+    {
+      name: 'fetchUserById',
+      call: () => Pendo.fetchUserById(mockClient, HOST, 'user@example.com'),
+      mockResponse: { id: 'v1' },
+    },
+    {
+      name: 'findAccountStream',
+      call: () => Pendo.findAccountStream(mockClient, HOST, 'acct1'),
+      mockResponse: { id: 'acct1' },
+    },
+    {
+      name: 'getMetadataSchema',
+      call: () => Pendo.getMetadataSchema(mockClient, HOST, 'visitor'),
+      mockResponse: {},
+    },
+    {
+      name: 'getVisitorHistory',
+      call: () => Pendo.getVisitorHistory(mockClient, HOST, 'v1', new Date()),
+      mockResponse: [],
+    },
+    {
+      name: 'getPages',
+      call: () => Pendo.getPages(mockClient, HOST),
+      mockResponse: [],
+    },
+    {
+      name: 'getFeatures',
+      call: () => Pendo.getFeatures(mockClient, HOST),
+      mockResponse: [],
+    },
+    {
+      name: 'getTrackTypes',
+      call: () => Pendo.getTrackTypes(mockClient, HOST),
+      mockResponse: [],
+    },
+    {
+      name: 'getGuides',
+      call: () => Pendo.getGuides(mockClient, HOST, ['g1']),
+      mockResponse: [],
+    },
+  ].forEach(({ name, call, mockResponse }) => {
+    it(`${name} sends {{setting.apiKey}} with secure: true`, () => {
+      mockRequest.mockImplementation(() => Promise.resolve(mockResponse));
+      return call().toPromise().then(() => {
+        expect(mockRequest).toHaveBeenCalledWith(expect.objectContaining({
+          headers: expect.objectContaining(SECURE_HEADER),
+          secure: true,
+        }));
+      });
+    });
+  });
+
+  it('runAggregation sends {{setting.apiKey}} with secure: true', () => {
+    mockRequest.mockImplementation(() => Promise.resolve({ results: [] }));
+    return Pendo.runAggregation(mockClient, HOST, {}).toArray().toPromise().then(() => {
+      expect(mockRequest).toHaveBeenCalledWith(expect.objectContaining({
+        headers: expect.objectContaining(SECURE_HEADER),
+        secure: true,
+      }));
+    });
+  });
+});
+
+// ─── fetchUserById ────────────────────────────────────────────────────────────
+
+describe('fetchUserById', () => {
+  it('requests the correct visitor URL', () => {
+    mockRequest.mockImplementation(() => Promise.resolve({ id: 'user@example.com' }));
+    return Pendo.fetchUserById(mockClient, HOST, 'user@example.com').toPromise().then(() => {
+      expect(mockRequest).toHaveBeenCalledWith(expect.objectContaining({
+        url: 'https://app.pendo.io/api/v1/visitor/user@example.com',
+        type: 'GET',
+      }));
+    });
+  });
+});
+
+// ─── findUsersByField ─────────────────────────────────────────────────────────
+
+describe('findUsersByField', () => {
+  it('prepends _lc_ to the field key before requesting', () => {
+    mockRequest.mockImplementation(() => Promise.resolve([{ id: 'v1' }]));
+    return Pendo.findUsersByField(mockClient, HOST, 'visitor/email', 'u@example.com').toPromise().then(() => {
+      expect(mockRequest).toHaveBeenCalledWith(expect.objectContaining({
+        url: 'https://app.pendo.io/api/v1/visitor/metadata/visitor/_lc_email/u@example.com',
+      }));
+    });
+  });
+
+  it('does not double-apply _lc_ if already present', () => {
+    mockRequest.mockImplementation(() => Promise.resolve([{ id: 'v1' }]));
+    return Pendo.findUsersByField(mockClient, HOST, 'visitor/_lc_email', 'u@example.com').toPromise().then(() => {
+      expect(mockRequest).toHaveBeenCalledWith(expect.objectContaining({
+        url: 'https://app.pendo.io/api/v1/visitor/metadata/visitor/_lc_email/u@example.com',
+      }));
+    });
+  });
+
+  it('emits each matching user', () => {
+    const users = [{ id: 'v1' }, { id: 'v2' }];
+    mockRequest.mockImplementation(() => Promise.resolve(users));
+    return Pendo.findUsersByField(mockClient, HOST, 'visitor/email', 'u@example.com')
+      .toArray().toPromise().then((result) => {
+        expect(result).toEqual(users);
+      });
+  });
+
+  it('errors when no users are returned', () => {
+    mockRequest.mockImplementation(() => Promise.resolve([]));
+    return Pendo.findUsersByField(mockClient, HOST, 'visitor/email', 'u@example.com')
+      .toPromise()
+      .then(() => { throw new Error('expected rejection'); })
+      .catch((err) => {
+        expect(err.message).toBe('No Users Found');
+      });
+  });
+});
+
+// ─── runAggregation ───────────────────────────────────────────────────────────
+
+describe('runAggregation', () => {
+  it('sends a POST with the aggregation body as JSON', () => {
+    const agg = { source: { visitors: null } };
+    mockRequest.mockImplementation(() => Promise.resolve({ results: [] }));
+    return Pendo.runAggregation(mockClient, HOST, agg).toArray().toPromise().then(() => {
+      expect(mockRequest).toHaveBeenCalledWith(expect.objectContaining({
+        url: 'https://app.pendo.io/api/v1/aggregation',
+        type: 'POST',
+        data: JSON.stringify(agg),
+      }));
+    });
+  });
+
+  it('emits each result row', () => {
+    const results = [{ count: 5 }, { count: 3 }];
+    mockRequest.mockImplementation(() => Promise.resolve({ results }));
+    return Pendo.runAggregation(mockClient, HOST, {}).toArray().toPromise().then((emitted) => {
+      expect(emitted).toEqual(results);
+    });
+  });
+});
+
+// ─── getVisitorHistory ────────────────────────────────────────────────────────
+
+describe('getVisitorHistory', () => {
+  it('includes a numeric starttime parameter in the URL', () => {
+    mockRequest.mockImplementation(() => Promise.resolve([]));
+    return Pendo.getVisitorHistory(mockClient, HOST, 'v1', new Date('2024-06-15T14:30:00Z'))
+      .toPromise().then(() => {
+        const { url } = mockRequest.mock.calls[0][0];
+        expect(url).toMatch(/\/api\/v1\/visitor\/v1\/history\?starttime=\d+/);
+      });
+  });
+
+  it('normalizes the date to midnight before computing starttime', () => {
+    mockRequest.mockImplementation(() => Promise.resolve([]));
+    const date = new Date('2024-06-15T14:30:45.999Z');
+    return Pendo.getVisitorHistory(mockClient, HOST, 'v1', date).toPromise().then(() => {
+      const { url } = mockRequest.mock.calls[0][0];
+      const starttime = parseInt(url.match(/starttime=(\d+)/)[1], 10);
+      const d = new Date(starttime);
+      expect(d.getSeconds()).toBe(0);
+      expect(d.getMinutes()).toBe(0);
+      expect(d.getMilliseconds()).toBe(0);
+    });
+  });
+});
+
+// ─── getGuides ────────────────────────────────────────────────────────────────
+
+describe('getGuides', () => {
+  it('returns empty observable immediately without making a request for empty ids', () => {
+    return Pendo.getGuides(mockClient, HOST, []).toPromise().then((result) => {
+      expect(result).toEqual([]);
+      expect(mockRequest).not.toHaveBeenCalled();
+    });
+  });
+
+  it('joins multiple ids into the query string', () => {
+    mockRequest.mockImplementation(() => Promise.resolve([]));
+    return Pendo.getGuides(mockClient, HOST, ['g1', 'g2', 'g3']).toPromise().then(() => {
+      expect(mockRequest).toHaveBeenCalledWith(expect.objectContaining({
+        url: 'https://app.pendo.io/api/v1/guide?id=g1,g2,g3',
+      }));
+    });
+  });
+
+  it('returns empty array when the request fails', () => {
+    mockRequest.mockImplementation(() => Promise.reject(new Error('not found')));
+    return Pendo.getGuides(mockClient, HOST, ['g1']).toPromise().then((result) => {
+      expect(result).toEqual([]);
+    });
+  });
+});
+
+// ─── getItemId ────────────────────────────────────────────────────────────────
+
+describe('getItemId', () => {
+  [
+    [{ pageId: 'p1' },      'p1'],
+    [{ featureId: 'f1' },   'f1'],
+    [{ guideId: 'g1' },     'g1'],
+    [{ trackTypeId: 't1' }, 't1'],
+  ].forEach(([item, expected]) => {
+    it(`returns ${expected} for ${Object.keys(item)[0]}`, () => {
+      expect(Pendo.getItemId(item)).toBe(expected);
+    });
+  });
+});

--- a/src/sources/ZAFClient.js
+++ b/src/sources/ZAFClient.js
@@ -1,6 +1,5 @@
 import Rx from 'rxjs';
 import R from 'ramda';
-import Pendo from './PendoClient';
 import Storage from './Storage';
 
 const initZAF = R.memoize(() => {
@@ -80,8 +79,12 @@ const ZAF = {
     return ZAF.getContext().map( (ctx) => ctx.ticketId );
   },
 
-  getApiToken () {
-    return ZAF.getMetadata().map( (md) => md.settings.token );
+  getPendoHost () {
+    return ZAF.getMetadata().map( (md) => md.settings['pendo-host'] || 'app.pendo.io' );
+  },
+
+  getClient () {
+    return zaf$;
   },
 
   getIDLookupField () {
@@ -95,8 +98,6 @@ const ZAF = {
 zaf$.subscribe(resize, (e) => console.error(e) );
 ZAF.getTicketId()
   .subscribe(initStorage, console.error);
-
-ZAF.getApiToken().subscribe(Pendo.initialize);
 
 
 export default ZAF;

--- a/zendesk-app/.gitignore
+++ b/zendesk-app/.gitignore
@@ -1,0 +1,1 @@
+settings.yml

--- a/zendesk-app/manifest.json
+++ b/zendesk-app/manifest.json
@@ -14,12 +14,19 @@
   },
   "version": "1.6.4",
   "frameworkVersion": "2.0",
+  "domainWhitelist": ["{{setting.pendo-host}}"],
   "parameters": [
     {
-      "name":     "token",
+      "name":     "apiKey",
       "type":     "text",
       "required": true,
       "secure":   true
+    },
+    {
+      "name":     "pendo-host",
+      "type":     "text",
+      "required": true,
+      "secure":   false
     },
     {
       "name":     "pendo-lookup-field",


### PR DESCRIPTION
## Summary

- Renamed `token` → `apiKey` with `secure: true` in manifest (existing secure settings can't be renamed in-place)
- Added required `pendo-host` setting (e.g. `app.pendo.io`, `app.eu.pendo.io`) and wired it into `domainWhitelist` — replaces the old approach of encoding region in the token suffix
- Switched all Pendo API calls from `fetch()` to `client.request()` with `secure: true` and `X-Pendo-Integration-Key: {{setting.apiKey}}`, so the key is substituted server-side by ZAF and never appears in the browser
- Added `zendesk-app/.gitignore` to ensure `settings.yml` is excluded from the ZAT package

## Test plan

- [x] 29 new Jest unit tests pass (`npm test -- --testPathPattern=PendoClient`) — security contract verified for every API method
- [x] `npm run build` compiles clean
- [x] ~~ZAT local serve~~ **Note:** `zat server` + `?zat=true` does NOT work with secure settings — Zendesk's proxy returns `422 InstallationNotFound` because ZAT has no real installation record. Must test via private app install (see below)
- [x] Installed as a private app in `d3v-pendo-platformhelp`, disabled the old Pendo app to avoid conflicts, opened a ticket without `?zat=true` — visitor/account data loads successfully
- [x] Confirmed API calls in browser devtools route through `https://d3v-pendo-platformhelp.zendesk.com/api/v2/zendesk_apps_proxy/proxy/apps/secure/...` — the real API key is never visible in the browser
- [x] `zat package` output does not include `settings.yml` (excluded via `zendesk-app/.gitignore`)

## Migration notes for existing installs

Installers will need to reconfigure two settings:
- **apiKey** — the Pendo integration key (UUID only, no suffix)
- **pendo-host** — the Pendo API host for their region (e.g. `app.pendo.io` for US, `app.eu.pendo.io` for EU)

[APP-149847](https://pendo-io.atlassian.net/browse/APP-149847)

[APP-149847]: https://pendo-io.atlassian.net/browse/APP-149847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ